### PR TITLE
Sequential send

### DIFF
--- a/assets/js/live/hooks/WebCam.js
+++ b/assets/js/live/hooks/WebCam.js
@@ -31,8 +31,7 @@ export default WebCam = {
     return setInterval(() => {
       if (webcamVideo.paused) return;
       const dataURL = webcamCaptureCanvas.toDataURL("image/jpeg", this.imageQuality);
-      this.pushEvent("send_image_to_mec", { image: dataURL });
-      this.pushEvent("send_image_to_cloud", { image: dataURL });
+      this.pushEvent("send_image", { image: dataURL });
     }, 1000 / this.fps);
   },
   mounted() {

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -62,7 +62,7 @@ config :zcamex, ZcamexWeb.Endpoint,
 config :zcamex, dev_routes: true
 
 # Do not include metadata nor timestamps in development logs
-config :logger, :console, format: "[$level] $message\n"
+config :logger, :console, format: "$time [$level] $message\n"
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.

--- a/lib/zcamex_web/live/page_live.ex
+++ b/lib/zcamex_web/live/page_live.ex
@@ -3,10 +3,10 @@ defmodule ZcamexWeb.PageLive do
   alias Zcamex.{HTTPSender, ZenohSender}
   require Logger
 
-  @protocol_options ["http", "zenoh"]
+  @protocol_options ["zenoh", "http"]
   @default_protocol "zenoh"
-  @default_fps "5"
-  @default_image_quality "0.5"
+  @default_fps "2"
+  @default_image_quality "0.2"
 
   def mount(_params, _session, socket) do
     znodes = %{

--- a/lib/zcamex_web/live/page_live.ex
+++ b/lib/zcamex_web/live/page_live.ex
@@ -52,78 +52,37 @@ defmodule ZcamexWeb.PageLive do
      })}
   end
 
-  def handle_event("send_image_to_mec", %{"image" => image}, socket) do
+  def handle_event("send_image", %{"image" => image}, socket) do
     %{selected_protocol: selected_protocol} = socket.assigns
     %{znodes: znodes} = socket.assigns
 
-    {:noreply,
-     socket
-     |> start_async(:send_to_mec, fn -> handle_send(selected_protocol, :mec, znodes, image) end)}
+    %{mec: mec_result, cloud: cloud_result} = handle_send(selected_protocol, znodes, image)
+
+    socket = handle_result(mec_result, :mec, socket)
+    socket = handle_result(cloud_result, :cloud, socket)
+
+    {:noreply, socket}
   end
 
-  def handle_event("send_image_to_cloud", %{"image" => image}, socket) do
-    %{selected_protocol: selected_protocol} = socket.assigns
-    %{znodes: znodes} = socket.assigns
-
-    {:noreply,
-     socket
-     |> start_async(:send_to_cloud, fn ->
-       handle_send(selected_protocol, :cloud, znodes, image)
-     end)}
+  defp handle_result({:ok, result}, destination, socket) do
+    socket
+    |> assign_error(destination, nil)
+    |> push_event("#{destination}_returned", result)
   end
 
-  def handle_async(:send_to_mec, {:ok, {:ok, result}}, socket) do
-    {:noreply,
-     socket
-     |> assign_error(:mec, nil)
-     |> push_event("mec_returned", result)}
+  defp handle_result({:error, message}, destination, socket) do
+    socket
+    |> assign_error(destination, message)
+    |> push_event("#{destination}_returned", %{
+      returned_image: nil,
+      latency: nil
+    })
   end
 
-  def handle_async(:send_to_mec, {:ok, {:error, message}}, socket) do
-    {:noreply,
-     socket
-     |> assign_error(:mec, message)
-     |> push_event("mec_returned", %{
-       returned_image: nil,
-       latency: nil
-     })}
-  end
-
-  def handle_async(:send_to_mec, {:exit, {exception, _stacktrace}}, socket) do
-    {:noreply,
-     socket
-     |> assign_error(:mec, Exception.message(exception))
-     |> push_event("mec_returned", %{
-       returned_image: nil,
-       latency: nil
-     })}
-  end
-
-  def handle_async(:send_to_cloud, {:ok, {:ok, result}}, socket) do
-    {:noreply,
-     socket
-     |> assign_error(:cloud, nil)
-     |> push_event("cloud_returned", result)}
-  end
-
-  def handle_async(:send_to_cloud, {:ok, {:error, message}}, socket) do
-    {:noreply,
-     socket
-     |> assign_error(:cloud, message)
-     |> push_event("cloud_returned", %{
-       returned_image: nil,
-       latency: nil
-     })}
-  end
-
-  def handle_async(:send_to_cloud, {:exit, {exception, _stacktrace}}, socket) do
-    {:noreply,
-     socket
-     |> assign_error(:cloud, Exception.message(exception))
-     |> push_event("cloud_returned", %{
-       returned_image: nil,
-       latency: nil
-     })}
+  defp handle_send(protocol, znodes, image) do
+    mec_result = handle_send(protocol, :mec, znodes, image)
+    cloud_result = handle_send(protocol, :cloud, znodes, image)
+    %{mec: mec_result, cloud: cloud_result}
   end
 
   defp handle_send(protocol, destination, znodes, image) do


### PR DESCRIPTION
MECとCloudへのPing/Pongを並行に行うのをやめて、MECのPing/Pong後にCloudのPing/Pongを実行するように変更しました。